### PR TITLE
Pkg.clone correction

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,5 +4,7 @@ This module provides essential capabilities to deal with measurements in Monte C
 
 To install, run
 
-Pkg.clone("https://www.github.com/pebroecker/MonteCarloObservable.jl")
+```
+Pkg.clone("https://github.com/pebroecker/MonteCarloObservable.jl")
+```
 


### PR DESCRIPTION
The command to install (clone) the package wasn't working. I fixed it.

(Presumed reason why it didn't work: the www in the Url, because this might lead to redirects which are somehow not allowed)